### PR TITLE
fix: message statistic page header cell layout

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -29332,7 +29332,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
                         }
                         if (canViewStats) {
                             items.add(LocaleController.getString("ViewStats", R.string.ViewStats));
-                            options.add(28);
+                            options.add(OPTION_STATISTICS);
                             icons.add(R.drawable.msg_stats);
                         }
                         if (allowUnpin) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/MessageStatisticActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/MessageStatisticActivity.java
@@ -1004,11 +1004,11 @@ public class MessageStatisticActivity extends BaseFragment implements Notificati
                     HeaderCell headerCell = (HeaderCell) holder.itemView;
                     if (position == overviewHeaderRow) {
                         headerCell.setTopMargin(9);
-                        headerCell.setPadding(0, 0, 0, AndroidUtilities.dp(8));
+                        headerCell.setPadding(AndroidUtilities.dp(16), 0, AndroidUtilities.dp(16), AndroidUtilities.dp(8));
                         headerCell.setText(LocaleController.formatString("StatisticOverview", R.string.StatisticOverview));
                     } else {
                         headerCell.setTopMargin(11);
-                        headerCell.setPadding(0, 0, 0, 0);
+                        headerCell.setPadding(AndroidUtilities.dp(16), 0, AndroidUtilities.dp(16), 0);
                         headerCell.setText(LocaleController.formatString("PublicShares", R.string.PublicShares));
                     }
                     break;


### PR DESCRIPTION
修复消息统计数据页面标题布局

![photo_2024-07-07_19-05-31](https://github.com/NextAlone/Nagram/assets/10793522/f1186cde-514b-4ca7-8db6-9e2fcbf63bc1)

官方版本没这个问题，应该是这个提交导致的 dd08362cc6163094fb7f28366a6629ca5d16c958

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a layout issue in the message statistics page and improves code readability in the chat activity. The main focus is on fixing the header cell layout, which was likely introduced by a previous commit. The changes ensure proper padding and alignment of header cells in the message statistics view, potentially resolving visual inconsistencies with the official version of the application.

- **Bug Fixes**:
    - Corrected the layout of header cells in the message statistics page by adding horizontal padding.
- **Enhancements**:
    - Replaced a magic number with a named constant for the statistics option in the chat activity.

<!-- Generated by sourcery-ai[bot]: end summary -->